### PR TITLE
Documentation improvements

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -9,7 +9,15 @@ html.writer-html4 .rst-content dl:not(.docutils)>dt, html.writer-html5 .rst-cont
     line-height: normal;
     background: transparent !important;
     color: #2980b9;
-    border-top: 3px solid #44b78b; !important
+    border-top: 3px solid #44b78b !important;
     padding: 6px;
     position: relative;
+}
+
+.wy-menu-vertical header, .wy-menu-vertical p.caption {
+    color: #3fb78d;
+}
+
+.wy-nav-top {
+    background: #3fb78d;
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,19 +4,24 @@
 .. mdinclude:: konfuzio.md
 
 .. toctree::
-   :caption: Konfuzio Python SDK
-   :glob:
 
-   crawler/docs/konfuzio_sdk/index
+   self
+
+.. toctree::
+   :caption: Konfuzio Python SDK
+
+   crawler/docs/konfuzio_sdk/sdkreadme
+   crawler/docs/konfuzio_sdk/helloworld
+   crawler/docs/konfuzio_sdk/sourcecode
 
 .. toctree::
    :caption: Training Package
-   :glob:
 
-   crawler/docs/training_package/index
+   crawler/docs/training_package/trainingpackage
 
 .. toctree::
    :caption: Web App
-   :glob:
 
-   crawler/docs/web_app/index
+   crawler/docs/web_app/api
+   crawler/docs/web_app/changelog
+   crawler/docs/web_app/coordinates

--- a/docs/konfuzio.md
+++ b/docs/konfuzio.md
@@ -4,11 +4,11 @@ Our **API Documentation** is available online via https://app.konfuzio.com/api. 
 
 The Konfuzio Software Development Kit, the **Konfuzio SDK**, can be installed via [pip install konfuzio-sdk](https://pypi.org/project/konfuzio-sdk/). Find examples in Python and review the source code on [GitHub](https://github.com/konfuzio-ai/document-ai-python-sdk).
 
-In addition, enterprise clients do have access to our [Python Konfuzio Trainer Module](https://github.com/konfuzio-ai/document-ai-python-sdk/blob/update-documentation/docs/training_documentation.md) to define, train and run custom Document AI.
+In addition, enterprise clients do have access to our [Python Konfuzio Trainer Module](./training_documentation.html) to define, train and run custom Document AI.
 
 Download the **On-Prem and Private Cloud** documentation to deploy Konfuzio on a single VM or on your cluster. Use [this link](https://deep-tech.com/pdf/konfuzio_on_prem.pdf) to access the latest version.
 
-The [Changelog of our Server](https://github.com/konfuzio-ai/document-ai-python-sdk/blob/update-documentation/docs/changelog_app.md) provides you with insights about any (future) release.
+The [Changelog of our Server](./changelog_app.html) provides you with insights about any (future) release.
 
 **This technical documentation is updated frequently. Please feel free to share your feedback via info@konfuzio.com**.
 


### PR DESCRIPTION
A note about the toctree: to fix the `<notitle>` issue I had to move the sub-toctrees from the various `crawler/docs/x/index.rst` files to the root `index.rst`. As a result, these sub-toctree files can be removed.