### PR TITLE
Fix: there shouldn't be spaces in BIO labels, and ignore empty tokens

### DIFF
--- a/konfuzio_sdk/data.py
+++ b/konfuzio_sdk/data.py
@@ -840,6 +840,8 @@ class Document(Data):
 
             with open(self.bio_scheme_file_path, 'w', encoding="utf-8") as f:
                 for word, tag in converted_text:
+                    if " " in tag:  # there shouldn't be spaces in BIO labels
+                        tag = tag.replace(" ", "_")
                     f.writelines(word + ' ' + tag + '\n')
                 f.writelines('\n')
 
@@ -850,6 +852,8 @@ class Document(Data):
                 if line == '\n':
                     continue
                 word, tag = line.replace('\n', '').split(' ')
+                if "_" in tag:  # get the space back
+                    tag = tag.replace("_", " ")
                 bio_annotations.append((word, tag))
 
         return bio_annotations

--- a/konfuzio_sdk/utils.py
+++ b/konfuzio_sdk/utils.py
@@ -232,7 +232,9 @@ def convert_to_bio_scheme(text: str, annotations: List) -> List[Tuple[str, str]]
         temp_str = text[start:end]
         tmp_list = nltk.word_tokenize(temp_str)
 
-        if len(tmp_list) > 1:
+        if len(tmp_list) == 0:
+            continue
+        elif len(tmp_list) > 1:
             tagged_entities.append((tmp_list[0], 'B-' + label_name))
             for w in tmp_list[1:]:
                 tagged_entities.append((w, 'I-' + label_name))


### PR DESCRIPTION
As I mentioned in the email to Florian and Ana, labels with spaces in them (such as "Steuerrechtliche Abzüge") are problematic for BIO schemes. I suggest replacing spaces with an underscore (perhaps double underscore?) during writing of the BIO scheme, and then reading back the label by doing the reverse in order to maintain compatibility with the labels from the platform.

The other fix is about ignoring empty tokens produced by `nltk.word_tokenize`, caused by "words" that only have spaces or other blank characters in them (these seem to come up a lot in documents like invoices and payslips).